### PR TITLE
use Cucumber's API instead of invoking Cucumber in a child_process

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,7 @@
-var es = require('event-stream');
-var spawn = require('child_process').spawn;
+var through2 = require('through2');
 var glob = require('simple-glob');
 var fs = require('fs');
-
-var binPath = (process.platform === 'win32') ? '.\\node_modules\\.bin\\cucumber-js.cmd' : './node_modules/cucumber/bin/cucumber.js';
-
-binPath = fs.existsSync(binPath) ? binPath : __dirname + ((process.platform === 'win32') ? '\\' : '/') + binPath;
+var Cucumber = require('cucumber');
 
 var cucumber = function(options) {
     var runOptions = [];
@@ -13,11 +9,11 @@ var cucumber = function(options) {
     // load support files and step_definitions from options
     var files = [];
     if (options.support) {
-        files.concat(glob([].concat(options.support)));
+        files = files.concat(glob([].concat(options.support)));
     }
 
     if (options.steps) {
-        files.concat(glob([].concat(options.steps)));
+        files = files.concat(glob([].concat(options.steps)));
     }
 
     files.forEach(function(file) {
@@ -29,33 +25,32 @@ var cucumber = function(options) {
     var format = options.format || 'pretty';
     runOptions.push(format);
 
+    var features = [];
 
-    var run = function(argument, callback) {
-        var filename = argument.path;
+    var collect = function(file, enc, callback) {
+        var filename = file.path;
         if (filename.indexOf(".feature") === -1) {
             return callback();
         }
 
-        var processOptions = runOptions.slice(0);
-        processOptions.push(filename);
-        
-        var cli = spawn(binPath, processOptions);
-
-        var output = [];
-
-        cli.stdout.on('data', function(data) {
-            output.push(data);
-        });
-
-        cli.on('exit', function(exitCode) {
-            var data = Buffer.concat(output).toString();
-            process.stdout.write(data);
-            process.stdout.write('\r\nFeature: ' + filename + '\r\n');
-        });
-        return callback();
+        features.push(filename);
+        callback();
     };
 
-    return es.map(run);
+    var run = function(callback) {
+        var argv = ['node', 'cucumber-js'];
+        argv.push.apply(argv, runOptions);
+        argv.push.apply(argv, features);
+        Cucumber.Cli(argv).run(function(succeeded) {
+            if (succeeded) {
+                callback()
+            } else {
+                callback(new Error("Cucumber tests failed!"))
+            }
+        })
+    };
+
+    return through2.obj(collect, run);
 };
 
 module.exports = cucumber;

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ var cucumber = function(options) {
         Cucumber.Cli(argv).run(function(succeeded) {
             if (succeeded) {
                 callback()
+                stream.emit('end')
             } else {
                 callback(new Error("Cucumber tests failed!"))
             }

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ var cucumber = function(options) {
         var argv = ['node', 'cucumber-js'];
         argv.push.apply(argv, runOptions);
         argv.push.apply(argv, features);
+        var stream = this
         Cucumber.Cli(argv).run(function(succeeded) {
             if (succeeded) {
                 callback()

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "cucumber": "^0.4.4",
-    "event-stream": "^3.1.7",
-    "simple-glob": "~0.1.0"
+    "simple-glob": "~0.1.0",
+    "through2": "^0.6.3"
   }
 }


### PR DESCRIPTION
This pull request also fixes several additional issues:

- Make step and support options actually work: `[].concat` does not modify the array, but returns a new one.
- Wait for the steps to run before continuing. Run every feature file in a single call.
- Make the Gulp task fail if Cucumber tests fail.