### PR TITLE
Fix tags options to handle array of tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,13 +34,14 @@ gulp.task('cucumber', function() {
 
 `options.format` supports cucumbers standard output formats : `summary`, `pretty` (default), `json`, `progress`
 
-You can use `options.tags` to specify which range of scenarios for test suite, for example:
+You can use `options.tags` to specify range of scenarios for test suite, for example:
 
 ```js
-'tags': '@auth,@profile,~@wip',
+'tags': '@auth,@profile',
 ```
 
-This will run all @auth and @profile tagged scenarios except those marked as @wip
+This will run all scenarios tagged with @auth and all scenarios tagged with @profile.
+It can be string or array of strings. See more on tags [here](https://github.com/cucumber/cucumber/wiki/Tags).
 
 
 Running tests:

--- a/features/gulp-cucumber.feature
+++ b/features/gulp-cucumber.feature
@@ -1,10 +1,11 @@
 Feature: gulp-cucumber
 
+  @gulpcucumber
   Scenario: Using gulp-cucumber
     When the features files are piped to gulp-cucumber
     Then Cucumber should run the features
 
-  @wip
+  @gulpcucumber @wip
   Scenario: Using tags filter
     When the scenario is excluded from tests
     Then this error should be ignored

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,7 +9,7 @@ gulp.task('cucumber', function() {
         'steps': 'features/step_definitions/*_steps.js',
         'support': 'features/support/*.js',
         'format': 'summary',
-        'tags': '~@wip'
+        'tags': ['@gulpcucumber', '~@wip']
     })).once('end', function() {
         console.log('stream end!!');
     });

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var Cucumber = require('cucumber');
 var glob = require('simple-glob');
+var util = require('util');
 var through2 = require('through2');
 
 var cucumber = function(options) {
@@ -23,9 +24,14 @@ var cucumber = function(options) {
     var format = options.format || 'pretty';
     runOptions.push(format);
 
+    var tags;
     if (options.tags) {
-        runOptions.push('--tags');
-        runOptions.push(options.tags);
+        tags = util.isArray(options.tags) ? options.tags : [options.tags];
+
+        tags.forEach(function(t) {
+            runOptions.push('--tags');
+            runOptions.push(t);
+        });
     }
 
     var features = [];


### PR DESCRIPTION
Hi,

turns out that I didnt check tags well enough, we can use that full potential of that feature only by supporting array of ranges.

Tags in single tags string is parsed with OR operator plus there is AND operator between items in array.

Im sorry, it should be like that from the beginning :)