### PR TITLE
bumped cucumber-js version to 0.8.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "gulp": "^3.8.8"
   },
   "dependencies": {
-    "cucumber": "^0.7.0",
+    "cucumber": "^0.8.0",
     "simple-glob": "~0.1.0",
     "through2": "^0.6.3"
   }


### PR DESCRIPTION
The 0.8.0 release of cucumber-js included API changes rendering the cucumber-js documentation (callbacks in world.js) incompatible with the 0.7 version used in gulp-cucumber. More details: https://github.com/cucumber/cucumber-js/releases/tag/v0.8.0