### PR TITLE
Fix emitting and add emitError option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,15 @@ gulp.task('cucumber', function() {
 
 **You have to set `options.steps` and `options.support` for preventing caching these files by require.cache**
 
+---
+
 `options.format` supports cucumbers standard output formats : `summary`, `pretty` (default), `json`, `progress`. You can use an array for multiple formats.
 
+---
+
 `options.compiler` supports cucumbers [compiler](https://github.com/cucumber/cucumber-js#transpilers). `<file_extension>:<module_name>`
+
+---
 
 You can use `options.tags` to specify range of scenarios for test suite, for example:
 
@@ -47,6 +53,13 @@ You can use `options.tags` to specify range of scenarios for test suite, for exa
 This will run all scenarios tagged with @auth and all scenarios tagged with @profile.
 It can be string or array of strings. See more on tags [here](https://github.com/cucumber/cucumber/wiki/Tags).
 
+---
+
+`options.emitErrors` will suppress the gulp error:
+
+```js
+'emitErrors': false
+```
 
 Running tests:
 ==

--- a/failures/gulp-cucumber.feature
+++ b/failures/gulp-cucumber.feature
@@ -1,0 +1,11 @@
+Feature: gulp-cucumber
+
+  @gulpcucumber
+  Scenario: Using gulp-cucumber
+    When the features files are piped to gulp-cucumber
+    Then Cucumber should run the features
+
+  @gulpcucumber @wip
+  Scenario: Using tags filter
+    When the scenario is excluded from tests
+    Then this error should be ignored

--- a/failures/step_definitions/gulp-cucumber_steps.js
+++ b/failures/step_definitions/gulp-cucumber_steps.js
@@ -1,0 +1,27 @@
+var expect = require('chai').expect;
+
+module.exports = function() {
+    this.When(/^the features files are piped to gulp\-cucumber$/, function (callback) {
+        // Well, the feature files are being piped here right now.
+        // Otherwise, how could the code get here?
+        this.meow();
+        callback();
+    });
+    this.Then(/^Cucumber should run the features$/, function (callback) {
+        // Well, the features are being run here right now.
+        // Otherwise, how could the code get here?
+        expect(100).to.equal(200);
+        callback();
+    });
+
+    this.When(/^the scenario is excluded from tests$/, function (callback) {
+        // Well, the features are being run here right now.
+        // Otherwise, how could the code get here?
+        callback();
+    });
+
+    this.Then(/^this error should be ignored$/, function (callback) {
+        // Trigger error and if tags option work it will never be called
+        callback.fail('It should never be called');
+    });
+};

--- a/failures/support/meow.js
+++ b/failures/support/meow.js
@@ -1,0 +1,5 @@
+module.exports = function() {
+    this.World.prototype.meow = function() {
+        console.log('Meow!');
+    };
+};

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,40 +2,166 @@ var gulp = require('gulp');
 var expect = require('chai').expect;
 var spawn = require('child_process').spawn;
 var cucumber = require('./');
+var runSequence = require('run-sequence');
 
-
-gulp.task('cucumber', function() {
-    return gulp.src('features/*').pipe(cucumber({
-        'steps': 'features/step_definitions/*_steps.js',
-        'support': 'features/support/*.js',
-        'format': ['summary'],
-        'tags': ['@gulpcucumber', '~@wip']
-    })).once('end', function() {
-        console.log('end');
-    });
+gulp.task('test', function (cb) {
+    runSequence('test:options', 'test:customend', 'test:failure', 'test:customerror', cb);
 });
 
-gulp.task('test', function(callback) {
-    var p = spawn('gulp', ['cucumber']);
+gulp.task('test:options', function (callback) {
+    var p = spawn('gulp', ['cucumber:options']);
     var chunks = [];
     p.stderr.pipe(process.stderr);
     p.stdout.pipe(process.stdout);
     p.stdout.setEncoding('utf8');
-    p.stdout.on('data', function(chunk) {
+    p.stdout.on('data', function (chunk) {
         chunks.push(chunk);
     });
-    p.on('close', function(status) {
+    p.on('close', function (status) {
         try {
             if (status !== 0) {
                 throw new Error('gulp-cucumber exited: ' + status);
             } else {
                 var text = chunks.join('');
+                expect(text).to.match(/Starting 'cucumber:options'.../);
                 expect(text).to.match(/Meow!/);
-                expect(text).to.match(/end/);
+                expect(text).to.match(/cucumber:options end event/);
+                expect(text).to.match(/Finished 'cucumber:options'/);
             }
             callback();
         } catch (e) {
             callback(e);
         }
     });
+});
+
+gulp.task('cucumber:options', function () {
+    return gulp.src('features/*').pipe(cucumber({
+        'steps': 'features/step_definitions/*_steps.js',
+        'support': 'features/support/*.js',
+        'format': ['summary'],
+        'tags': ['@gulpcucumber', '~@wip']
+    })).once('end', function () {
+        console.log('cucumber:options end event');
+    });
+});
+
+gulp.task('test:failure', function (callback) {
+    var p = spawn('gulp', ['cucumber:failure']);
+    var chunks = [];
+    p.stderr.pipe(process.stderr);
+    p.stdout.pipe(process.stdout);
+    p.stdout.setEncoding('utf8');
+    p.stdout.on('data', function (chunk) {
+        chunks.push(chunk);
+    });
+    p.on('close', function (status) {
+        try {
+            if (status !== 1) {
+                throw new Error('gulp-cucumber exited: ' + status);
+            } else {
+                var text = chunks.join('');
+                expect(text).to.match(/Starting 'cucumber:failure'.../);
+                expect(text).to.match(/Meow!/);
+                expect(text).to.match(/AssertionError: expected 100 to equal 200/);
+                expect(text).to.match(/'cucumber:failure' errored/);
+            }
+            callback();
+        } catch (e) {
+            callback(e);
+        }
+    });
+});
+
+gulp.task('cucumber:failure', function (done) {
+    return gulp.src('failures/*')
+        .pipe(cucumber({
+            'steps': 'failures/step_definitions/*_steps.js',
+            'support': 'failures/support/*.js',
+            'format': ['summary'],
+            'tags': ['@gulpcucumber', '~@wip']
+        }));
+});
+
+gulp.task('test:customend', function (callback) {
+    var p = spawn('gulp', ['cucumber:customend']);
+    var chunks = [];
+    p.stderr.pipe(process.stderr);
+    p.stdout.pipe(process.stdout);
+    p.stdout.setEncoding('utf8');
+    p.stdout.on('data', function (chunk) {
+        chunks.push(chunk);
+    });
+    p.on('close', function (status) {
+        try {
+            if (status !== 0) {
+                throw new Error('gulp-cucumber exited: ' + status);
+            } else {
+                var text = chunks.join('');
+                expect(text).to.match(/Starting 'cucumber:customend'.../);
+                expect(text).to.match(/Meow!/);
+                expect(text).to.match(/cucumber:customend end event/);
+                expect(text).to.match(/Finished 'cucumber:customend'/);
+            }
+            callback();
+        } catch (e) {
+            callback(e);
+        }
+    });
+});
+
+gulp.task('cucumber:customend', function (done) {
+    gulp.src('features/*')
+        .pipe(cucumber({
+            'steps': 'features/step_definitions/*_steps.js',
+            'support': 'features/support/*.js',
+            'format': ['summary'],
+            'tags': ['@gulpcucumber', '~@wip']
+        }))
+        .once('end', function () {
+            console.log('cucumber:customend end event');
+            done();
+        });
+});
+
+gulp.task('test:customerror', function (callback) {
+    var p = spawn('gulp', ['cucumber:customerror']);
+    var chunks = [];
+    p.stderr.pipe(process.stderr);
+    p.stdout.pipe(process.stdout);
+    p.stdout.setEncoding('utf8');
+    p.stdout.on('data', function (chunk) {
+        chunks.push(chunk);
+    });
+    p.on('close', function (status) {
+        try {
+            if (status !== 1) {
+                throw new Error('gulp-cucumber exited: ' + status);
+            } else {
+                var text = chunks.join('');
+                expect(text).to.match(/Starting 'cucumber:customerror'.../);
+                expect(text).to.match(/Meow!/);
+                expect(text).to.match(/AssertionError: expected 100 to equal 200/);
+                expect(text).to.match(/cucumber:customerror error event/);
+                expect(text).to.match(/'cucumber:customerror' errored/);
+            }
+            callback();
+        } catch (e) {
+            callback(e);
+        }
+    });
+});
+
+gulp.task('cucumber:customerror', function (done) {
+    gulp.src('failures/*')
+        .pipe(cucumber({
+            'steps': 'failures/step_definitions/*_steps.js',
+            'support': 'failures/support/*.js',
+            'format': ['summary'],
+            'tags': ['@gulpcucumber', '~@wip']
+        }))
+        .once('error', function (err) {
+            console.log('cucumber:customerror error event');
+            done(err);
+        });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -182,6 +182,8 @@ gulp.task('test:customerror', function (callback) {
                 expect(text).to.match(/AssertionError: expected 100 to equal 200/);
                 expect(text).to.match(/cucumber:customerror error event/);
                 expect(text).to.match(/'cucumber:customerror' errored/);
+                
+                expect(text).to.not.match(/cucumber:customerror end event/);
             }
             callback();
         } catch (e) {
@@ -201,5 +203,9 @@ gulp.task('cucumber:customerror', function (done) {
         .once('error', function (err) {
             console.log('cucumber:customerror error event');
             done(err);
+        })
+        .once('end', function () {
+            console.log('cucumber:customerror end event');
+            done();
         });
 });

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ var clearFileCache = function(filePath) {
 module.exports = function(options) {
     var files = [];
     var runOptions = [];
+    var emitErrors = true;
 
     if (options.support) {
         files = files.concat(glob([].concat(options.support)));
@@ -50,6 +51,10 @@ module.exports = function(options) {
         runOptions.push(options.compiler);
     }
 
+    if (options.emitErrors === false) {
+        emitErrors = false;
+    }
+
     var features = [];
 
     var collect = function(file, enc, callback) {
@@ -69,7 +74,7 @@ module.exports = function(options) {
 
         var stream = this;
         Cucumber.Cli(argv).run(function(succeeded) {
-            if (succeeded) {
+            if (succeeded || !emitErrors) {
                 stream.emit("end");
             } else {
                 stream.emit("error", new Error('Cucumber tests failed!'));

--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ module.exports = function(options) {
         callback();
     };
 
-    var run = function(callback) {
+    var run = function() {
         var argv = ['node', 'cucumber-js'];
 
         argv.push.apply(argv, runOptions);
@@ -70,9 +70,9 @@ module.exports = function(options) {
         var stream = this;
         Cucumber.Cli(argv).run(function(succeeded) {
             if (succeeded) {
-                callback();
+                stream.emit("end");
             } else {
-                callback(new Error('Cucumber tests failed!'));
+                stream.emit("error", new Error('Cucumber tests failed!'));
             }
         });
     };

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   "license": "MIT",
   "devDependencies": {
     "chai": "^1.10.0",
-    "gulp": "^3.8.8"
+    "gulp": "^3.8.8",
+    "run-sequence": "^1.1.5"
   },
   "dependencies": {
     "cucumber": "^0.10.2",


### PR DESCRIPTION
The error/end emitting was making things hard on me. This PR:

* Adds proper `emit('error')` and `emit('end')` behavior
* Adds a handful of tests to verify emit behavior
* Adds an explicit `emitError` flag to turn off the error emit

Related to https://github.com/vgamula/gulp-cucumber/issues/33.