### PR TITLE
Update to cucumber ^3.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - "6.3"
+  - "6"
+  - "7"
+  - "8"
 install:
   - npm install
 script:

--- a/failures/step_definitions/gulp-cucumber_steps.js
+++ b/failures/step_definitions/gulp-cucumber_steps.js
@@ -1,27 +1,28 @@
-var expect = require('chai').expect;
+const expect = require('chai').expect;
+const { defineSupportCode } = require('cucumber');
 
-module.exports = function() {
-    this.When(/^the features files are piped to gulp\-cucumber$/, function (callback) {
+defineSupportCode(({ When, Then }) => {
+    When(/^the features files are piped to gulp\-cucumber$/, function (callback) {
         // Well, the feature files are being piped here right now.
         // Otherwise, how could the code get here?
         this.meow();
         callback();
     });
-    this.Then(/^Cucumber should run the features$/, function (callback) {
+    Then(/^Cucumber should run the features$/, function (callback) {
         // Well, the features are being run here right now.
         // Otherwise, how could the code get here?
         expect(100).to.equal(200);
         callback();
     });
 
-    this.When(/^the scenario is excluded from tests$/, function (callback) {
+    When(/^the scenario is excluded from tests$/, function (callback) {
         // Well, the features are being run here right now.
         // Otherwise, how could the code get here?
         callback();
     });
 
-    this.Then(/^this error should be ignored$/, function (callback) {
+    Then(/^this error should be ignored$/, function (callback) {
         // Trigger error and if tags option work it will never be called
         callback.fail('It should never be called');
     });
-};
+})

--- a/failures/support/meow.js
+++ b/failures/support/meow.js
@@ -1,5 +1,11 @@
-module.exports = function() {
-    this.World.prototype.meow = function() {
+const { defineSupportCode } = require('cucumber');
+
+class World {
+    meow() {
         console.log('Meow!');
-    };
-};
+    }
+}
+
+defineSupportCode(({ setWorldConstructor }) => {
+    setWorldConstructor(World);
+});

--- a/features/step_definitions/gulp-cucumber_steps.js
+++ b/features/step_definitions/gulp-cucumber_steps.js
@@ -1,24 +1,24 @@
-module.exports = function() {
-    this.When(/^the features files are piped to gulp\-cucumber$/, function (callback) {
+const { defineSupportCode } = require('cucumber');
+
+defineSupportCode(({ When, Then }) => {
+    When(/^the features files are piped to gulp\-cucumber$/, function (callback) {
         // Well, the feature files are being piped here right now.
         // Otherwise, how could the code get here?
         this.meow();
         callback();
     });
-    this.Then(/^Cucumber should run the features$/, function (callback) {
+    Then(/^Cucumber should run the features$/, function (callback) {
         // Well, the features are being run here right now.
         // Otherwise, how could the code get here?
         callback();
     });
-
-    this.When(/^the scenario is excluded from tests$/, function (callback) {
+    When(/^the scenario is excluded from tests$/, function (callback) {
         // Well, the features are being run here right now.
         // Otherwise, how could the code get here?
         callback();
     });
-
-    this.Then(/^this error should be ignored$/, function (callback) {
+    Then(/^this error should be ignored$/, function (callback) {
         // Trigger error and if tags option work it will never be called
         callback.fail('It should never be called');
     });
-};
+});

--- a/features/support/meow.js
+++ b/features/support/meow.js
@@ -1,5 +1,11 @@
-module.exports = function() {
-    this.World.prototype.meow = function() {
+const { defineSupportCode } = require('cucumber');
+
+class World {
+    meow() {
         console.log('Meow!');
-    };
-};
+    }
+}
+
+defineSupportCode(({ setWorldConstructor }) => {
+    setWorldConstructor(World);
+});

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,16 +1,16 @@
-var gulp = require('gulp');
-var expect = require('chai').expect;
-var spawn = require('child_process').spawn;
-var cucumber = require('./');
-var runSequence = require('run-sequence');
+const gulp = require('gulp');
+const expect = require('chai').expect;
+const execa = require('execa');
+const cucumber = require('./');
+const runSequence = require('run-sequence');
 
 gulp.task('test', function (cb) {
     runSequence('test:options', 'test:customend', 'test:failure', 'test:ignorefailure', 'test:customerror', cb);
 });
 
 gulp.task('test:options', function (callback) {
-    var p = spawn('gulp', ['cucumber:options']);
-    var chunks = [];
+    const p = execa('gulp', ['cucumber:options']);
+    const chunks = [];
     p.stderr.pipe(process.stderr);
     p.stdout.pipe(process.stdout);
     p.stdout.setEncoding('utf8');
@@ -22,7 +22,7 @@ gulp.task('test:options', function (callback) {
             if (status !== 0) {
                 throw new Error('gulp-cucumber exited: ' + status);
             } else {
-                var text = chunks.join('');
+                const text = chunks.join('');
                 expect(text).to.match(/Starting 'cucumber:options'.../);
                 expect(text).to.match(/Meow!/);
                 expect(text).to.match(/cucumber:options end event/);
@@ -36,19 +36,19 @@ gulp.task('test:options', function (callback) {
 });
 
 gulp.task('cucumber:options', function () {
-    return gulp.src('features/*').pipe(cucumber({
+    return gulp.src('features/**').pipe(cucumber({
         'steps': 'features/step_definitions/*_steps.js',
         'support': 'features/support/*.js',
         'format': ['summary'],
-        'tags': ['@gulpcucumber', '~@wip']
+        'tags': '@gulpcucumber and not @wip',
     })).once('end', function () {
         console.log('cucumber:options end event');
     });
 });
 
 gulp.task('test:failure', function (callback) {
-    var p = spawn('gulp', ['cucumber:failure']);
-    var chunks = [];
+    const p = execa('gulp', ['cucumber:failure']);
+    const chunks = [];
     p.stderr.pipe(process.stderr);
     p.stdout.pipe(process.stdout);
     p.stdout.setEncoding('utf8');
@@ -60,10 +60,12 @@ gulp.task('test:failure', function (callback) {
             if (status !== 1) {
                 throw new Error('gulp-cucumber exited: ' + status);
             } else {
-                var text = chunks.join('');
+                const text = chunks.join('');
                 expect(text).to.match(/Starting 'cucumber:failure'.../);
                 expect(text).to.match(/Meow!/);
-                expect(text).to.match(/AssertionError: expected 100 to equal 200/);
+                expect(text).to.match(/AssertionError/);
+                expect(text).to.match(/-100/);
+                expect(text).to.match(/\+200/);
                 expect(text).to.match(/'cucumber:failure' errored/);
             }
             callback();
@@ -79,13 +81,13 @@ gulp.task('cucumber:failure', function (done) {
             'steps': 'failures/step_definitions/*_steps.js',
             'support': 'failures/support/*.js',
             'format': ['summary'],
-            'tags': ['@gulpcucumber', '~@wip']
+            'tags': '@gulpcucumber and not @wip'
         }));
 });
 
 gulp.task('test:ignorefailure', function (callback) {
-    var p = spawn('gulp', ['cucumber:ignorefailure']);
-    var chunks = [];
+    const p = execa('gulp', ['cucumber:ignorefailure']);
+    const chunks = [];
     p.stderr.pipe(process.stderr);
     p.stdout.pipe(process.stdout);
     p.stdout.setEncoding('utf8');
@@ -97,10 +99,12 @@ gulp.task('test:ignorefailure', function (callback) {
             if (status !== 0) {
                 throw new Error('gulp-cucumber exited: ' + status);
             } else {
-                var text = chunks.join('');
+                const text = chunks.join('');
                 expect(text).to.match(/Starting 'cucumber:ignorefailure'.../);
                 expect(text).to.match(/Meow!/);
-                expect(text).to.match(/AssertionError: expected 100 to equal 200/);
+                expect(text).to.match(/AssertionError/);
+                expect(text).to.match(/-100/);
+                expect(text).to.match(/\+200/);
                 expect(text).to.match(/Finished 'cucumber:ignorefailure'/);
             }
             callback();
@@ -116,14 +120,14 @@ gulp.task('cucumber:ignorefailure', function (done) {
             'steps': 'failures/step_definitions/*_steps.js',
             'support': 'failures/support/*.js',
             'format': ['summary'],
-            'tags': ['@gulpcucumber', '~@wip'],
+            'tags': '@gulpcucumber and not @wip',
             'emitErrors': false
         }));
 });
 
 gulp.task('test:customend', function (callback) {
-    var p = spawn('gulp', ['cucumber:customend']);
-    var chunks = [];
+    const p = execa('gulp', ['cucumber:customend']);
+    const chunks = [];
     p.stderr.pipe(process.stderr);
     p.stdout.pipe(process.stdout);
     p.stdout.setEncoding('utf8');
@@ -135,7 +139,7 @@ gulp.task('test:customend', function (callback) {
             if (status !== 0) {
                 throw new Error('gulp-cucumber exited: ' + status);
             } else {
-                var text = chunks.join('');
+                const text = chunks.join('');
                 expect(text).to.match(/Starting 'cucumber:customend'.../);
                 expect(text).to.match(/Meow!/);
                 expect(text).to.match(/cucumber:customend end event/);
@@ -154,7 +158,7 @@ gulp.task('cucumber:customend', function (done) {
             'steps': 'features/step_definitions/*_steps.js',
             'support': 'features/support/*.js',
             'format': ['summary'],
-            'tags': ['@gulpcucumber', '~@wip']
+            'tags': '@gulpcucumber and not @wip'
         }))
         .once('end', function () {
             console.log('cucumber:customend end event');
@@ -163,8 +167,8 @@ gulp.task('cucumber:customend', function (done) {
 });
 
 gulp.task('test:customerror', function (callback) {
-    var p = spawn('gulp', ['cucumber:customerror']);
-    var chunks = [];
+    const p = execa('gulp', ['cucumber:customerror']);
+    const chunks = [];
     p.stderr.pipe(process.stderr);
     p.stdout.pipe(process.stdout);
     p.stdout.setEncoding('utf8');
@@ -176,13 +180,15 @@ gulp.task('test:customerror', function (callback) {
             if (status !== 1) {
                 throw new Error('gulp-cucumber exited: ' + status);
             } else {
-                var text = chunks.join('');
+                const text = chunks.join('');
                 expect(text).to.match(/Starting 'cucumber:customerror'.../);
                 expect(text).to.match(/Meow!/);
-                expect(text).to.match(/AssertionError: expected 100 to equal 200/);
+                expect(text).to.match(/AssertionError/);
+                expect(text).to.match(/-100/);
+                expect(text).to.match(/\+200/);
                 expect(text).to.match(/cucumber:customerror error event/);
                 expect(text).to.match(/'cucumber:customerror' errored/);
-                
+
                 expect(text).to.not.match(/cucumber:customerror end event/);
             }
             callback();
@@ -198,7 +204,7 @@ gulp.task('cucumber:customerror', function (done) {
             'steps': 'failures/step_definitions/*_steps.js',
             'support': 'failures/support/*.js',
             'format': ['summary'],
-            'tags': ['@gulpcucumber', '~@wip']
+            'tags': '@gulpcucumber and not @wip'
         }))
         .once('error', function (err) {
             console.log('cucumber:customerror error event');

--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
   "author": "Volodymyr Gamula <v.gamula@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "chai": "^1.10.0",
+    "chai": "^4.1.1",
+    "execa": "^0.8.0",
     "gulp": "^3.8.8",
-    "run-sequence": "^1.1.5"
+    "gulp-istanbul": "^1.1.2",
+    "run-sequence": "^2.1.0"
   },
   "dependencies": {
-    "cucumber": "^1.2.1",
-    "simple-glob": "~0.1.0",
-    "through2": "^0.6.3"
+    "cucumber": "^3.0.0",
+    "glob": "^7.1.2",
+    "through2": "^2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,10 +21,13 @@
     "execa": "^0.8.0",
     "gulp": "^3.8.8",
     "gulp-istanbul": "^1.1.2",
-    "run-sequence": "^2.1.0"
+    "run-sequence": "^2.1.0",
+    "cucumber": "^3.0.0"
+  },
+  "peerDependencies": {
+    "cucumber": "^3.0.0"
   },
   "dependencies": {
-    "cucumber": "^3.0.0",
     "glob": "^7.1.2",
     "through2": "^2.0.3"
   }


### PR DESCRIPTION
@vgamula Recently I've been trying to use cucumber with my projects together with gulp-istanbul, and found that this lib is still using cucumber 1.x.x. So I upgrade all the dependencies to the latest versions and modified the tags implementation to go along with cucumber 3.x.
Can you please take a look?
If things are ok, please help bump npm version and release it?

Thanks!